### PR TITLE
Add layout and style for search page

### DIFF
--- a/app/assets/components/listing/README.md
+++ b/app/assets/components/listing/README.md
@@ -8,6 +8,7 @@ Custom component to display a list of results, containing filters (if provided),
 
 {{ listing({
   showPagination: true,
+  pageType: "bulletin",
   items: [
     {
       title: "Item one",
@@ -82,6 +83,7 @@ The filter macro takes the following arguments:
 
 | Name                       | Type     | Required  | Description  |
 | ---------------------------|----------|-----------|--------------|
-| **filter**                  | array    | No        | An array of filter types; see filter component for more information
+| **filter**                 | array    | No        | An array of filter types; see filter component for more information
 | **items**                  | array    | Yes       | An array of results; see summaryList for more information |
 | **showPagination**         | boolean  | No        | Display pagination for this example? |
+| **pageType**               | string   | No        | The list item display will be varied based on the page type. It can be "search", "bulletin" |

--- a/app/assets/components/listing/template.njk
+++ b/app/assets/components/listing/template.njk
@@ -62,18 +62,36 @@
         </div>
       {% endif %}
 
-      <hr />
-
-      {% for item in list.items %}
-        <div class="nhsuk-listing__item">
-          <h3><a href="#">{{ item.title }}</a></h3>
-          {{ summaryList(item.summaryList) }}
-        </div>
+      {% if list.items.length > 0 %}
+          {% if list.pageType == "search" %}
+            <ul class="nhsuk-list nhsuk-list--border">
+              {% for item in list.items %}
+                  <li>
+                      <span class="app-search-results-category">{{item.content_type}}</span>
+                      <a href="#" class="app-search-results-item">{{item.title}}</a>
+                      <p class="nhsuk-body-s nhsuk-u-margin-top-1">{{item.summary}}</p>
+                      <div class="nhsuk-review-date">
+                          <p class="nhsuk-body-s">
+                              {{item.published_date}}
+                          </p>
+                      </div>
+                  </li>
+              {% endfor %}
+            </ul>
+          {% elseif list.pageType == "bulletin" %}
+            <hr/>
+            {% for item in list.items %}
+                <div class="nhsuk-listing__item">
+                  <h3><a href="#">{{ item.title }}</a></h3>
+                  {{ summaryList(item.summaryList) }}
+                </div>
+            {% endfor %}
+          {% endif %}
       {% else %}
-        <div class="nhsuk-listing__no-items">
-          No results
-        </div>
-      {% endfor %}
+          <div class="nhsuk-listing__no-items">
+            No results
+          </div>
+      {% endif %}
 
       {% if list.showPagination %}
         {{ pagination({

--- a/app/assets/components/search/_search.scss
+++ b/app/assets/components/search/_search.scss
@@ -1,0 +1,103 @@
+.nhsuk-header__search-form--search-results {
+  margin-bottom: 40px;
+  background-color: transparent;
+  display: flex;
+  padding: 0;
+  width: 100%;
+}
+
+.nhsuk-search__input {
+  -ms-flex-positive: 2;
+  -webkit-appearance: listbox;
+  background-color: $color_nhsuk-white !important;
+  border-bottom: 1px solid $color_nhsuk-grey-3;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 0;
+  border-left: 1px solid $color_nhsuk-grey-3;
+  border-right: 0;
+  border-top: 1px solid $color_nhsuk-grey-3;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 0;
+  flex-grow: 2;
+  font-size: inherit;
+  height: 52px;
+  margin: 0;
+  outline: 0;
+  padding: 0 16px;
+  width: 100%;
+
+  &:focus {
+    border: 4px solid $color_nhsuk-yellow;
+    box-shadow: inset 0 0 0 4px $color_nhsuk-black;
+    padding: 0 16px 0 13px;
+    outline: 0;
+  }
+}
+
+.app-search-results-category {
+  color: #4c6272;
+  display: block;
+  font-size: 14px;
+}
+
+.nhsuk-list--border {
+  >li {
+    border-bottom: 1px solid #d8dde0;
+    padding: 8px 0 16px;
+    > {
+      :first-child {
+        margin-top: 0;
+      }
+      :last-child {
+        margin-bottom: 0;
+      }
+    }
+    &:first-of-type {
+      border-top: 1px solid #d8dde0;
+      padding: 16px 0;
+    }
+    .nhsuk-review-date {
+      margin-top: 0;
+
+      .nhsuk-body-s {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+.nhsuk-search__submit {
+  color: $color_nhsuk-white;
+  background-color: $color_nhsuk-green;
+  border: 0;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 4px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 4px;
+  float: right;
+  font-size: inherit;
+  height: 52px;
+  line-height: inherit;
+  margin: 0;
+  outline: 0;
+  padding: 8px 8px 0;
+  width: 52px;
+  &:hover {
+    background-color: #00662f;
+    cursor: pointer;
+  }
+  &:focus {
+    background-color: $color_nhsuk-yellow;
+    border-bottom: 4px solid $color_nhsuk-black;
+    box-shadow: none;
+    .nhsuk-icon__search {
+      fill: $color_nhsuk-black;
+    }
+  }
+}
+
+.nhsuk-icon__search {
+  fill: $color_nhsuk-white;
+  height: 38px;
+  width: 38px;
+}

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -22,3 +22,4 @@
 @import '../components/related-nav/related-nav';
 @import '../components/signage/signage';
 @import '../components/image/image';
+@import '../components/search/search';

--- a/app/views/lks/bulletin.html
+++ b/app/views/lks/bulletin.html
@@ -1,14 +1,14 @@
 {% extends "lks-layout.html" %}
 
 {% block pageTitle %}
-  Listing - HEE
+  Bulletin - HEE
 {% endblock %}
 
 {% block content %}
   <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-two-thirds">
-      <h1>Listing</h1>
-      
+    <div class="nhsuk-grid-column-full">
+      <h2>Bulletins</h2>
+      <p class="nhsuk-lede-text">Find current awareness from our libraries and trusts across the NHS.</p>
     </div>
   </div>
   

--- a/app/views/lks/listing.html
+++ b/app/views/lks/listing.html
@@ -14,6 +14,7 @@
   
   {{ listing({
     showPagination: true,
+    pageType: "bulletin",
     items: [
       {
         title: "Item one",

--- a/app/views/lks/search.html
+++ b/app/views/lks/search.html
@@ -1,0 +1,92 @@
+{% extends "lks-layout.html" %}
+
+{% block pageTitle %}
+Search - HEE
+{% endblock %}
+
+{% block content %}
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-full">
+        <h2>Search</h2>
+        <p class="nhsuk-lede-text">Search for terms within guidance pages and blog posts.</p>
+
+        <form method="get" action="/search/results">
+            <div class="nhsuk-form-group  nhsuk-header__search-form--search-results">
+                <label class="nhsuk-label nhsuk-u-visually-hidden" for="search-field">Enter a search term</label>
+                <input class="nhsuk-input nhsuk-search__input" type="search" name="q" autocomplete="on" id="search-field">
+                <button class="nhsuk-search__submit" type="submit">
+            <span class="nhsuk-u-visually-hidden">
+                Submit
+            </span>
+                    <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+                    </svg>
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+	{{ listing({
+      showPagination: true,
+      pageType: "search",
+      items: [
+      {
+        title: "Search result card",
+        content_type: "Guidance Page",
+        summary: "In mid-September HEE began a pilot to understand how best to help LKS in England move from using HDAS to using provider interfaces.",
+        published_date: "Published on 23 January 2021"
+      },
+      {
+        title: "Search result card",
+        content_type: "Guidance Page",
+        summary: "In mid-September HEE began a pilot to understand how best to help LKS in England move from using HDAS to using provider interfaces.",
+        published_date: "Published on 23 January 2021"
+      },
+      {
+        title: "Search result card",
+        content_type: "Guidance Page",
+        summary: "In mid-September HEE began a pilot to understand how best to help LKS in England move from using HDAS to using provider interfaces.",
+        published_date: "Published on 23 January 2021"
+      }
+    ],
+    filter: {
+      groups: [
+        {
+          title: "Content type",
+          items: [
+            {
+              text: "Guidance Page",
+              value: "guidance+page"
+            },
+            {
+              text: "Landing Page",
+              value: "landing+page"
+            },
+            {
+              text: "MiniHub",
+              value: "minihub"
+            }
+          ]
+        },
+        {
+          title: "Date",
+          items: [
+            {
+              text: "Item one",
+              value: "item+one"
+            },
+            {
+              text: "Item two",
+              value: "item+two"
+            },
+            {
+              text: "Item three",
+              value: "item+three"
+            }
+          ]
+        }
+      ]
+    }
+  }) }}
+{% endblock %}


### PR DESCRIPTION
## Description
- Add new view and template for this Search Result page design https://www.figma.com/file/olZRiuJrZXfEaNeMMb7aNp/HEE-Designs?node-id=230%3A3874
- The search page can be access from local URL http://localhost:3000/lks/search.
- The old listing page has been renamed to bulletin page because this view layout only be used by the bulletin page and can be accessed from http://localhost:3000/lks/bulletin
- The listing macro will be shared by bulletin page and search result page with differences on the list item display.
## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
