### PR TITLE
Search input styling fix

### DIFF
--- a/app/assets/components/search/_search.scss
+++ b/app/assets/components/search/_search.scss
@@ -6,7 +6,7 @@
   width: 100%;
 }
 
-.nhsuk-search__input {
+.nhsuk-search__input--search-results {
   -ms-flex-positive: 2;
   -webkit-appearance: listbox;
   background-color: $color_nhsuk-white !important;
@@ -66,7 +66,7 @@
   }
 }
 
-.nhsuk-search__submit {
+.nhsuk-search__submit--search-results {
   color: $color_nhsuk-white;
   background-color: $color_nhsuk-green;
   border: 0;
@@ -96,7 +96,7 @@
   }
 }
 
-.nhsuk-icon__search {
+.nhsuk-icon__search--search-results {
   fill: $color_nhsuk-white;
   height: 38px;
   width: 38px;

--- a/app/views/lks/search.html
+++ b/app/views/lks/search.html
@@ -13,12 +13,12 @@ Search - HEE
         <form method="get" action="/search/results">
             <div class="nhsuk-form-group  nhsuk-header__search-form--search-results">
                 <label class="nhsuk-label nhsuk-u-visually-hidden" for="search-field">Enter a search term</label>
-                <input class="nhsuk-input nhsuk-search__input" type="search" name="q" autocomplete="on" id="search-field">
-                <button class="nhsuk-search__submit" type="submit">
+                <input class="nhsuk-input nhsuk-search__input nhsuk-search__input--search-results" type="search" name="q" autocomplete="on" id="search-field">
+                <button class="nhsuk-search__submit nhsuk-search__submit--search-results" type="submit">
             <span class="nhsuk-u-visually-hidden">
                 Submit
             </span>
-                    <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <svg class="nhsuk-icon nhsuk-icon__search nhsuk-icon__search--search-results" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                         <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
                     </svg>
                 </button>


### PR DESCRIPTION
Inclusion of '--search-results' modifiers for Search Results specific override classes so that the search form for both header and search results could exists together without styling issues.