### PR TITLE
Feature/hee 224 cta card

### DIFF
--- a/app/assets/components/cta-card/README.md
+++ b/app/assets/components/cta-card/README.md
@@ -1,0 +1,121 @@
+# CTA Card
+
+## Quick start examples
+
+### Card with an title/link
+
+#### HTML markup
+
+```
+<div class="nhsuk-card nhsuk-card--clickable">
+    <div class="nhsuk-card__content">
+        <h2 class="nhsuk-card__heading">
+            <a class="nhsuk-card__link" href="http://hee.nhs.uk">CTA Card</a>
+        </h2>
+        <a class="nhsuk-button" href="http://hee.nhs.uk" draggable="false">
+            Save and continue
+        </a>
+    </div>
+</div>
+```
+
+
+#### Nunjucks macro
+
+```
+{{ ctaCard({
+    "heading": "CTA Card",
+    "clickable": "true",
+    "linkText": "Save and continue",
+    "href": "http://hee.nhs.uk"
+  })
+}}
+```
+### Card with an title/link/description
+
+#### HTML markup
+
+```
+<div class="nhsuk-cta-card nhsuk-cta-card--clickable">
+  <div class="nhsuk-cta-card__content">
+    <h2 class="nhsuk-cta-card__heading">
+      CTA Card
+    </h2>
+    <p class="nhsuk-cta-card__description">A call to action.</p>
+    <a class="nhsuk-button" href="https://www.nhs.uk" draggable="false">
+        Action
+    </a>
+  </div>
+</div>
+```
+
+#### Nunjucks macro
+
+```
+{{ ctaCard({
+    "heading": "CTA Card",
+    "clickable": "true",
+    "description": "A call to action.",
+    "linkText": "Save and continue",
+    "href": "http://hee.nhs.uk"
+  })
+}}
+```
+
+### Card with an image
+
+### Card with an title/link/image
+
+#### HTML markup
+
+```
+<div class="nhsuk-card nhsuk-card--clickable">
+    <img class="nhsuk-card__img" src="https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg" alt="">
+    <div class="nhsuk-card__content">
+        <h2 class="nhsuk-card__heading">
+            <a class="nhsuk-card__link" href="http://hee.nhs.uk">CTA Card</a>
+        </h2>
+        <p class="nhsuk-card__description">A call to action.</p>
+        <a class="nhsuk-button" href="http://hee.nhs.uk" draggable="false">
+            Save and continue
+        </a>
+    </div>
+</div>
+```
+
+#### Nunjucks macro
+
+```
+{{ ctaCard({
+    "heading": "CTA Card",
+    "clickable": "true",
+    "description": "A call to action.",
+    "imgURL": "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg",
+    "linkText": "Save and continue",
+    "href": "http://hee.nhs.uk"
+  })
+}}
+```
+
+### Nunjucks arguments
+
+The card Nunjucks macro takes the following arguments:
+
+| Name                | Type     | Required  | Description  |
+| --------------------|----------|-----------|--------------|
+| **heading**         | string   | Yes       | Text heading of the card. If headingHtml is provided, the heading argument will be ignored. |
+| **headingHtml**         | string   | Yes       | HTML heading of the card. If headingHtml is provided, the heading argument will be ignored. |
+| **headingClasses**         | string   | No        | Optional additional classes to add to heading. Separate each class with a space. |
+| **headingLevel**    | integer  | No        | Optional heading level for the card heading. Default: 2 |
+| **href**            | string   | No       | The value of the card button href attribute |
+| **linkText**            | string   | No       | The value of the card button label |
+| **clickable**            | boolean | No       | If set to true, then the class `nhsuk-cta-card--clickable` will be applied. |
+| **feature**            | boolean | No       | If set to true, then the class `nhsuk-cta-card__heading--feature` and `nhsuk-cta-card__content--feature` will be applied. |
+| **imgURL**          | string   | No        | The URL of the image in the card |
+| **imgALT**          | string   | No        | The alternative text of the image in the card |
+| **description**     | string   | No        | Text description within the card content. If descriptionHtml is provided, the description argument will be ignored. |
+| **descriptionHtml**     | string   | No        | HTML to use within the card content. If descriptionHtml is provided, the description argument will be ignored. |
+| **classes**         | string   | No        | Optional additional classes to add to the card. Separate each class with a space. |
+| **attributes**      | object   | No        | Any extra HTML attributes (for example data attributes) to add to the card. |
+
+If you are using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `html` can be a [security risk](https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting). Read more about this in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).

--- a/app/assets/components/cta-card/README.md
+++ b/app/assets/components/cta-card/README.md
@@ -1,4 +1,9 @@
 # CTA Card
+Based on the NHS prototype for the Card component. 
+
+Currently in draft as requesting feedback as to whether there are better ways to extend components in nunjucks, rather than copying and tweaking (as has been done here). 
+
+Also, would be worth discussing whether for something like this we need to create a new component, or whether just tweaking the Card components HTML to include a button would be better.
 
 ## Quick start examples
 

--- a/app/assets/components/cta-card/cta-card.js
+++ b/app/assets/components/cta-card/cta-card.js
@@ -1,0 +1,12 @@
+export default () => {
+  // Loops through dom and finds all elements with nhsuk-card--clickable class
+  document.querySelectorAll('.nhsuk-cta-card--clickable').forEach((panel) => {
+    // Check if panel has a link within it
+    if (panel.querySelector('a') !== null) {
+      // Clicks the link within the heading to navigate to desired page
+      panel.addEventListener('click', () => {
+        panel.querySelector('a').click();
+      });
+    }
+  });
+};

--- a/app/assets/components/cta-card/cta-card.scss
+++ b/app/assets/components/cta-card/cta-card.scss
@@ -1,0 +1,160 @@
+/* ==========================================================================
+   COMPONENTS / #CTACARD
+   ========================================================================== */
+
+/**
+ * 1. Is needed for the :active top positioning.
+ * 2. Border is used to create a divider between the white content
+ *    box and an image.
+ * 3. Creates the 'pressed down' effect when clicked.
+ * 4. Removes padding-top from headings directly after the card group.
+ * 5. Includes the border width to achieve the correct left alignment.
+ * 6. Stops the heading from spanning the full width of the card.
+ * 7. Removes padding top for the feature heading positioning.
+ */
+
+$card-border-width: 1px;
+$card-border-bottom-width: nhsuk-spacing(1);
+$card-border-color: $color_nhsuk-grey-4;
+$card-border-hover-color: $color_nhsuk-grey-3;
+
+.nhsuk-cta-card {
+  @include nhsuk-responsive-margin(7, 'bottom');
+
+  background: $color_nhsuk-white;
+  border: $card-border-width solid $card-border-color;
+  position: relative; /* [1] */
+  width: 100%;
+}
+
+.nhsuk-cta-card__img {
+  @include print-hide();
+
+  border-bottom: $card-border-width solid $color_nhsuk-grey-5; /* [2] */
+  display: block;
+  width: 100%;
+}
+
+.nhsuk-cta-card__content {
+  @include top-and-bottom();
+  @include nhsuk-responsive-padding(5);
+
+  position: relative;
+}
+
+.nhsuk-cta-card__heading,
+.nhsuk-cta-card__metadata,
+.nhsuk-cta-card__description {
+  margin-bottom: nhsuk-spacing(3);
+}
+
+/* Clickable card
+  ========================================================================== */
+
+.nhsuk-cta-card--clickable {
+  border-bottom-width: $card-border-bottom-width;
+
+  &:hover,
+  &:active {
+    cursor: pointer;
+
+    .nhsuk-cta-card__heading a,
+    .nhsuk-cta-card__link {
+      color: $nhsuk-link-hover-color;
+      text-decoration: none;
+
+      &:focus {
+        color: $nhsuk-focus-text-color;
+      }
+    }
+
+  }
+
+  &:hover {
+    border-color: $card-border-hover-color;
+  }
+
+  &:active {
+    border-color: $card-border-hover-color;
+    bottom: - $card-border-width; /* [3] */
+  }
+}
+
+/* Card group
+  ========================================================================== */
+
+/**
+* Card group allows you to have a row of cards.
+*
+* Flexbox is used to make each card in a row the same height.
+*/
+
+.nhsuk-cta-card-group {
+  @include flex();
+
+  margin-bottom: nhsuk-spacing(3);
+  padding: 0;
+
+  @include mq($until: desktop) {
+    margin-bottom: nhsuk-spacing(6);
+  }
+
+  + h2,
+  + .nhsuk-heading-l,
+  + h3,
+  + .nhsuk-heading-m, {
+    padding-top: 0; /* [4] */
+  }
+}
+
+.nhsuk-cta-card-group__item {
+  @include flex-item();
+
+  list-style-type: none;
+  margin-bottom: 0;
+
+  .nhsuk-cta-card {
+    margin-bottom: nhsuk-spacing(5);
+  }
+
+  @include mq($until: desktop) {
+
+    .nhsuk-cta-card {
+      margin-bottom: nhsuk-spacing(3);
+    }
+
+    &:last-child .nhsuk-cta-card {
+      margin-bottom: 0;
+    }
+  }
+}
+
+/* Card feature
+  ========================================================================== */
+
+.nhsuk-cta-card--feature {
+  @include nhsuk-responsive-margin(7, 'top');
+}
+
+.nhsuk-cta-card__heading--feature {
+  background: $color_nhsuk-blue;
+  color: $color_nhsuk-white;
+  display: inline-block;
+  left: - (nhsuk-spacing(4) + $card-border-width); /* [5] */
+  margin-bottom: nhsuk-spacing(2);
+  margin-right: - nhsuk-spacing(4); /* [6] */
+  padding: nhsuk-spacing(2) nhsuk-spacing(4);
+  position: relative;
+  top: - nhsuk-spacing(2);
+
+  @include mq($from: tablet) {
+    left: - (nhsuk-spacing(5) + $card-border-width); /* [5] */
+    margin-right: - nhsuk-spacing(5); /* [6] */
+    padding: nhsuk-spacing(2) nhsuk-spacing(5);
+    top: - nhsuk-spacing(3);
+  }
+}
+
+.nhsuk-cta-card__content--feature {
+  padding-top: 0 !important; // sass-lint:disable-line no-important /* [7] */
+}

--- a/app/assets/components/cta-card/macro.njk
+++ b/app/assets/components/cta-card/macro.njk
@@ -1,0 +1,3 @@
+{% macro ctaCard(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/assets/components/cta-card/template.njk
+++ b/app/assets/components/cta-card/template.njk
@@ -1,0 +1,28 @@
+{%- from 'button/macro.njk' import button %}
+
+{% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
+<div class="nhsuk-cta-card{% if params.clickable %} nhsuk-cta-card--clickable{% endif %}{% if params.feature %} nhsuk-cta-card--feature{% endif %}{%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {%- if params.imgURL %}
+  <img class="nhsuk-cta-card__img" src="{{ params.imgURL }}" alt="{{ params.imgALT }}">
+  {%- endif %}
+  <div class="nhsuk-cta-card__content{% if params.feature %} nhsuk-cta-card__content--feature{% endif %}">
+    {%- if params.headingHtml %}
+    {{ params.headingHtml | safe }}
+    {%- else %}
+    <h{{ headingLevel }} class="nhsuk-cta-card__heading{% if params.feature %} nhsuk-cta-card__heading--feature{% endif %} {%- if params.headingClasses %} {{ params.headingClasses }}{% endif %}">
+      {{ params.heading }}
+    </h{{ headingLevel }}>
+    {%- endif %}
+    {%- if params.descriptionHtml %}
+    {{ params.descriptionHtml | safe }}
+    {%- elif params.description %}
+    <p class="nhsuk-cta-card__description">{{ params.description | safe }}</p>
+    {%- else %}
+    {%- endif %}
+    {{ button({
+      "text": params.linkText,
+      "href": params.href,
+      "element": "a"
+    }) }}
+  </div>
+</div>

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -25,3 +25,4 @@
 @import '../components/search/search';
 @import '../components/contact/contact';
 @import '../components/resources/resources';
+@import '../components/cta-card/cta-card';

--- a/app/views/lks/content.html
+++ b/app/views/lks/content.html
@@ -42,6 +42,16 @@
       </div>
 
       <div class="nhsuk-grid-column-one-third">
+        {{ ctaCard({
+            "heading": "CTA Card",
+            "clickable": "true",
+            "description": "A call to action.",
+            "imgURL": "https://assets.nhs.uk/prod/images/A_0218_exercise-main_FKW1X7.width-690.jpg",
+            "linkText": "Save and continue",
+            "href": "http://hee.nhs.uk"
+          })
+        }}        
+        
         {{ relatedNav({
             "heading": "Quick Links",
             "subsections": [{

--- a/docs/views/template.html
+++ b/docs/views/template.html
@@ -43,6 +43,7 @@
 {%- from 'homepage-section/macro.njk' import homepageSection %}
 {%- from 'related-links-card/macro.njk' import relatedLinksCard %}
 {%- from 'resources/macro.njk' import resources %}
+{%- from 'cta-card/macro.njk' import ctaCard %}
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="ie8" lang="en"><![endif]--><!--[if IE 9]><html class="ie9" lang="en"><![endif]--><!--[if gt IE 9]><!--><html lang="en" style="{{ html_style }}"><!--<![endif]-->
   <head>


### PR DESCRIPTION
## Description
Based on the NHS prototype for the Card component. 

Currently in draft as requesting feedback as to whether there are better ways to extend components in nunjucks, rather than copying and tweaking (as has been done here). 

Also, would be worth discussing whether for something like this we need to create a new component, or whether just tweaking the Card components HTML to include a button would be better.

[PR84](https://github.com/Manifesto-Digital/hee-cms-platform/pull/84) on platform app does not use this. It uses a tweaked output of the NHS UK prototypes Card component.

Also, haven't worked out a way to get the [template JS](https://github.com/Manifesto-Digital/hee-prototypes/blob/1298aee04ea6b4cd3fb2ef11361984ea6ce080ea/app/assets/components/cta-card/cta-card.js) rendered. I see that the main.js should include custom JS for HEE, but haven't worked out how to include the js export fragments from within the components folder.

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
