### PR TITLE
HEE-263: filter component amendment to keep filters open by default

### DIFF
--- a/app/assets/components/filter/filter.js
+++ b/app/assets/components/filter/filter.js
@@ -32,7 +32,7 @@ export default () => {
       this.container.classList.add('nhsuk-filter--js');
 
       // Close groups
-      this.groups.forEach(group => group.classList.add('nhsuk-filter__group--closed'));
+      // this.groups.forEach(group => group.classList.add('nhsuk-filter__group--closed'));
 
       // Hide submit button
       if (this.submit) {


### PR DESCRIPTION
Just commented out the following line (to keep the filters open) so that we can go back in the future if required:

```
this.groups.forEach(group => group.classList.add('nhsuk-filter__group--closed'));
```